### PR TITLE
4096-bit RSA Keys

### DIFF
--- a/src/key_crypt.py
+++ b/src/key_crypt.py
@@ -8,7 +8,7 @@ private_key_path = os.getenv("PRIVATE_KEY_PATH")
 public_key_path = os.getenv("PUBLIC_KEY_PATH")
 
 def generate_key_pair():
-    key = RSA.generate(2048)
+    key = RSA.generate(4096)
     private_key = key.export_key()
     public_key = key.publickey().export_key()
     return private_key, public_key


### PR DESCRIPTION
Updated RSA key length to 4096 bits for enhanced security.

- Switched from 2048-bit to 4096-bit RSA keys, increasing the strength of the encryption.
- This change improves security by making keys more resistant to brute-force attacks and future-proofs against emerging threats.
- Note: This may introduce slight performance overhead in key generation and operations using the private key (e.g., decryption, signing).